### PR TITLE
Resolve DEVELOPER_DIR via xcode-select instead of hardcoding Xcode.app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -185,7 +185,15 @@
       ];
 
       xcodeMinCheck = minMajor: ''
-        export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+        # Prefer the Xcode currently selected via xcode-select, so this works regardless of
+        # where Xcode is installed or what it's named (versioned installs, /Applications/Xcode.app
+        # not existing or being a stale/dangling symlink, etc). Fall back to the previous
+        # hardcoded default if xcode-select has nothing configured.
+        DEVELOPER_DIR="$(/usr/bin/xcode-select -p 2>/dev/null || true)"
+        if [ -z "$DEVELOPER_DIR" ]; then
+          DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+        fi
+        export DEVELOPER_DIR
 
         if [ ! -x "$DEVELOPER_DIR/usr/bin/xcodebuild" ]; then
           echo "Error: Xcode is required at $DEVELOPER_DIR"

--- a/flake.nix
+++ b/flake.nix
@@ -185,11 +185,14 @@
       ];
 
       xcodeMinCheck = minMajor: ''
-        # Prefer the Xcode currently selected via xcode-select, so this works regardless of
-        # where Xcode is installed or what it's named (versioned installs, /Applications/Xcode.app
-        # not existing or being a stale/dangling symlink, etc). Fall back to the previous
-        # hardcoded default if xcode-select has nothing configured.
-        DEVELOPER_DIR="$(/usr/bin/xcode-select -p 2>/dev/null || true)"
+        # Respect Apple's normal precedence: an explicitly-set DEVELOPER_DIR wins, then the
+        # Xcode currently selected via xcode-select (works regardless of where Xcode is
+        # installed or what it's named — versioned installs, /Applications/Xcode.app not
+        # existing or being a stale/dangling symlink, etc), then the previous hardcoded
+        # default as a last resort.
+        if [ -z "$DEVELOPER_DIR" ]; then
+          DEVELOPER_DIR="$(/usr/bin/xcode-select -p 2>/dev/null || true)"
+        fi
         if [ -z "$DEVELOPER_DIR" ]; then
           DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
         fi


### PR DESCRIPTION
## Problem

`xcodeMinCheck` in `flake.nix` hardcodes:

```nix
export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
```

This breaks any setup where Xcode isn't installed at that exact path, which is common:
- Versioned installs (e.g. `Xcode-26.6.0.app`) with no `/Applications/Xcode.app` symlink at all.
- A `/Applications/Xcode.app` symlink that's dangling (points at a version that was since removed/replaced) — which is what I hit: `xcode-select -p` correctly resolved a working Xcode install, but the build still failed with `Error: Xcode is required at /Applications/Xcode.app/Contents/Developer` because that hardcoded path was checked instead.

## Fix

Resolve `DEVELOPER_DIR` from `xcode-select -p` first, falling back to the previous hardcoded default only if `xcode-select` has nothing configured (empty/failed), so existing setups that happen to have `/Applications/Xcode.app` are unaffected.

```nix
DEVELOPER_DIR="$(/usr/bin/xcode-select -p 2>/dev/null || true)"
if [ -z "$DEVELOPER_DIR" ]; then
  DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
fi
export DEVELOPER_DIR
```

## Testing

- `nix flake check --no-build` passes on `aarch64-darwin` (`xcode26` and `android-r27d` devShells evaluate cleanly).
- Verified the resolution logic directly: with a working `xcode-select -p`, `DEVELOPER_DIR` now resolves to the actual selected Xcode path (a non-default, versioned install in my case) instead of the hardcoded one; with the resolution command failing/returning empty, it falls back to the original hardcoded default, preserving prior behavior.
- Ran a full `./nix-ios.sh -p xcode26 -x --spm` build against this change and confirmed it now succeeds where it previously failed with the "Xcode is required at ..." error, given the same (dangling-symlink) environment.

This is a minimal, backward-compatible change — no new options, no behavior change for setups where `/Applications/Xcode.app` already resolves correctly.