### PR TITLE
Fix Nix toolchain dependencies across build profiles

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
         gperf
         python3
         perl
+        rsync
         ruby
       ];
 
@@ -183,7 +184,6 @@
         gtk-doc
         patch
         ragel
-        rsync
         tcl
         texinfo
         which


### PR DESCRIPTION
## Summary

- Move `rsync` from `linuxToolchainPackages` to `commonToolPackages`.

## Details

`rsync` is used by the FFmpeg installation scripts on all three native build platforms:

- [Android](https://github.com/arthenica/ffmpeg-kit-next/blob/ed837370d66c045c3fc454a667e5988d0b74ef7b/scripts/android/ffmpeg.sh#L530)
- [Apple](https://github.com/arthenica/ffmpeg-kit-next/blob/ed837370d66c045c3fc454a667e5988d0b74ef7b/scripts/apple/ffmpeg.sh#L704)
- [Linux](https://github.com/arthenica/ffmpeg-kit-next/blob/ed837370d66c045c3fc454a667e5988d0b74ef7b/scripts/linux/ffmpeg.sh#L525)

It is currently declared only in `linuxToolchainPackages`. Moving it to the common tool set prevents the Android and Apple Nix shells from depending on an `rsync` installation provided by the host.