### PR TITLE
fix(react-native/types): rename module to "ffmpeg-kit-next-react-native"

### DIFF
--- a/react-native/src/index.d.ts
+++ b/react-native/src/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'ffmpeg-kit-react-native' {
+declare module 'ffmpeg-kit-next-react-native' {
 
   export abstract class AbstractSession implements Session {
 


### PR DESCRIPTION
Fixes `File '/ffmpeg-kit-next/react-native/src/index.d.ts' is not a module.` TypeScript issue.